### PR TITLE
Features/updates 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.9
+  - 1.11
+  - 1.10
   - master
 
 # Don't email me the results of the test runs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,14 @@
 # OTHER  TORTIOUS ACTION,  ARISING  OUT OF  OR  IN CONNECTION  WITH  THE USE  OR
 # PERFORMANCE OF THIS SOFTWARE.
 
-FROM golang:1.8.3-stretch
+FROM golang:1.10.4-stretch as builder
+
+COPY . /go/src/github.com/rockyluke/drac-kvm
+WORKDIR /go/src/github.com/rockyluke/drac-kvm
+
+RUN go build
+
+FROM golang:1.10.4-stretch
 
 ENV DEBIAN_FRONTEND="noninteractive" \
     TZ="Europe/Amsterdam"
@@ -24,9 +31,11 @@ RUN apt-get update  -qq && \
       libx11-6 \
       x11-utils
 
-RUN go get github.com/rockyluke/drac-kvm
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENTRYPOINT [ "drac-kvm" ]
+COPY --from=builder /go/src/github.com/rockyluke/drac-kvm/drac-kvm /usr/bin/drac-kvm
 
-CMD [ "--help" ]
+ENTRYPOINT ["drac-kvm"]
+
+CMD ["--help"]
 # EOF

--- a/README.md
+++ b/README.md
@@ -71,12 +71,25 @@ This simple Go program should help ease the pain.
 
 ```bash
 drac-kvm --help
-Usage of drac-kvm
-  -h, --host="some.hostname.com": The DRAC host (or IP)
-  -j, --javaws="/usr/bin/javaws": The path to javaws binary
-  -p, --password=false: Prompt for password (optional, will use 'calvin' if not present)
-  -u, --username="": The DRAC username
-  -v, --version=-1: iDRAC version (6, 7 or 8)
+Usage of ./drac-kvm:
+  -d, --delay int
+    	Number of seconds to delay for javaws to start up & read jnlp before deleting it (default 10)
+  -h, --host string
+    	The DRAC host (or IP)
+  -j, --javaws string
+    	The path to javaws binary (default "/usr/bin/javaws")
+  -k, --keep-jnlp
+    	Keep JNLP files and do not clean them after failed start
+  -p, --password
+    	Prompt for password (optional, will use default vendor if not present)
+  -u, --username string
+    	The KVM username
+  -V, --vendor string
+    	The KVM Vendor
+  -v, --version int
+    	KVM vendor specific version for idrac: (6, 7 or 8) (default -1)
+  -w, --wait
+    	Wait for java console process end
 ```
 
 ### Example using default dell credentials (root/calvin)
@@ -108,6 +121,7 @@ cat ~/.drackvmrc
 # Useful if your environment has consistent usernames and
 # passwords for the KVMs.
 [defaults]
+javaws_path = /Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/javaws
 username = foo
 password = bar
 
@@ -126,6 +140,20 @@ password = password4root
 vendor = supermicro
 host = 10.33.0.2
 username = root
+```
+
+## Java Security
+
+Some versions of java are not compatible with older versions of ilo providers. If you receive an error like this
+
+[java-error](https://user-images.githubusercontent.com/67790/46364353-db72b080-c675-11e8-9d7e-3ab0540c51d6.png)
+
+You have to edit `$JAVA_HOME/lib/security/java.security` file and remove following entry `3DES_EDE_CBC` from line starting with `jdk.tls.disabledAlgorithms`. This is global setting and it can affect your system security.
+
+```diff
+
+- jdk.tls.disabledAlgorithms=SSLv3, RC4, MD5withRSA, DH keySize < 1024, EC keySize < 224, DES40_CBC, RC4_40, 3DES_EDE_CBC
++ jdk.tls.disabledAlgorithms=SSLv3, RC4, MD5withRSA, DH keySize < 1024, EC keySize < 224, DES40_CBC, RC4_40
 ```
 
 ## Credits

--- a/dell/drac6.go
+++ b/dell/drac6.go
@@ -5,7 +5,7 @@ package dell
 const viewer6 string = `
 <?xml version="1.0" encoding="UTF-8"?>
 <jnlp codebase="https://{{ .Host }}:443" spec="1.0+">
-<information>
+ <information>
   <title>iDRAC6 Console Redirection Client</title>
   <vendor>Dell Inc.</vendor>
    <icon href="https://{{ .Host }}:443/images/logo.gif" kind="splash"/>
@@ -27,19 +27,24 @@ const viewer6 string = `
    <all-permissions/>
  </security>
  <resources>
-   <j2se version="1.6 1.5 1.4+"/>
-   <jar href="https://{{ .Host }}:443/software/avctKVM.jar" download="eager" main="true" />
-   <jar href="https://{{ .Host }}:443/software/jpcsc.jar" download="eager"/>
+  <j2se version="1.6 1.5 1.4+"/>
+  <jar href="https://{{ .Host }}:443/software/avctKVM.jar" download="eager" main="true" />
+  <jar href="https://{{ .Host }}:443/software/jpcsc.jar" download="eager"/>
  </resources>
  <resources os="Windows">
-   <nativelib href="https://{{ .Host }}:443/software/avctKVMIOWin32.jar" download="eager"/>
-   <nativelib href="https://{{ .Host }}:443/software/avctVMWin32.jar" download="eager"/>
+  <nativelib href="https://{{ .Host }}:443/software/avctKVMIOWin32.jar" download="eager"/>
+  <nativelib href="https://{{ .Host }}:443/software/avctVMWin32.jar" download="eager"/>
  </resources>
-  <resources os="Linux">
-    <nativelib href="https://{{ .Host }}:443/software/avctKVMIOLinux.jar" download="eager"/>
-   <nativelib href="https://{{ .Host }}:443/software/avctVMLinux.jar" download="eager"/>
-  </resources>
-</jnlp>
+ <resources os="Linux">
+  <nativelib href="https://{{ .Host }}:443/software/avctKVMIOLinux.jar" download="eager"/>
+  <nativelib href="https://{{ .Host }}:443/software/avctVMLinux.jar" download="eager"/>
+ </resources>
+ <resources os="Mac OS X" arch="x86_64">
+  <nativelib href="https://{{ .Host }}:443/software/avctKVMIOMac64.jar" download="eager"/>
+  <nativelib href="https://{{ .Host }}:443/software/avctVMMac64.jar" download="eager"/>
+ </resources>
+
+  </jnlp>
 `
 
 // EOF

--- a/hp/ilo.go
+++ b/hp/ilo.go
@@ -75,7 +75,7 @@ func (d *KvmHpDriver) Viewer() (string, error) {
 			m := f.(map[string]interface{})
 			sessionKey := m["session_key"].(string)
 
-			cookie := http.Cookie{Name: "session_key", Value: sessionKey}
+			cookie := http.Cookie{Name: "sessionKey", Value: sessionKey}
 			req, _ := http.NewRequest("GET", "https://"+d.Host+"/html/jnlp_template.html", nil)
 			req.AddCookie(&cookie)
 

--- a/hp/ilo.go
+++ b/hp/ilo.go
@@ -75,7 +75,7 @@ func (d *KvmHpDriver) Viewer() (string, error) {
 			m := f.(map[string]interface{})
 			sessionKey := m["session_key"].(string)
 
-			cookie := http.Cookie{Name: "sessionKey", Value: sessionKey}
+			cookie := http.Cookie{Name: "session_key", Value: sessionKey}
 			req, _ := http.NewRequest("GET", "https://"+d.Host+"/html/jnlp_template.html", nil)
 			req.AddCookie(&cookie)
 

--- a/kvm/kvm.go
+++ b/kvm/kvm.go
@@ -57,7 +57,7 @@ func CreateKVM(Host string, Username string, Password string, Vendor string,
 			Host:     Host,
 			Username: Username,
 			Password: Password,
-			Version:  169,
+			Version:  Version,
 		}
 	case "hp":
 		driver = &hp.KvmHpDriver{

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// DracKVMVersion current application version
-	DracKVMVersion = "2.0.1"
+	DracKVMVersion = "1.2.0"
 )
 
 func promptPassword() string {

--- a/main.go
+++ b/main.go
@@ -175,8 +175,8 @@ func main() {
 		password = promptPassword()
 	}
 
-	// Version is only used with dell KVM vendor..
-	if vendor == "dell" && *_version == -1 {
+	// Version is only used with dell/supermicro KVM vendor..
+	if vendor != "hp" && *_version == -1 {
 		if value, err := cfg.Int(*_host, "version"); err == nil {
 			version = value
 		} else {

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// DracKVMVersion current application version
-	DracKVMVersion = "1.2.0"
+	DracKVMVersion = "2.2.0"
 )
 
 func promptPassword() string {
@@ -30,14 +30,13 @@ func promptPassword() string {
 	return string(password)
 }
 
-func getJavawsArgs(waitFlag bool) string {
-	var javawsArgs = "-jnlp"
+func getJavawsArgs(waitFlag bool, javaws string) string {
+	var javawsArgs = ""
 
-	cmd := exec.Command("java", "-version")
-	stderr, err := cmd.StderrPipe()
+	cmd := exec.Command(javaws)
+	stdout, err := cmd.StdoutPipe()
 
 	if err != nil {
-		//os.Remove(filename)
 		log.Fatalf("Java not present on your system... (%s)", err)
 	}
 
@@ -45,16 +44,23 @@ func getJavawsArgs(waitFlag bool) string {
 		log.Fatal(err)
 	}
 
-	slurp, _ := ioutil.ReadAll(stderr)
+	// HACK: javaws executed without any params returns exit code 255 test
+	// if we have it here don't fail.
+	slurp, _ := ioutil.ReadAll(stdout)
 	if err := cmd.Wait(); err != nil {
-		log.Fatal(err)
+		if !strings.Contains(err.Error(), "255") {
+			log.Fatal(err)
+		}
 	}
 
-	if strings.Contains(string(slurp[:]), "1.7") ||
-		strings.Contains(string(slurp[:]), "1.8") {
+	if strings.Contains(string(slurp[:]), "-wait") {
 		if waitFlag {
 			javawsArgs = "-wait"
 		}
+	}
+
+	if strings.Contains(string(slurp[:]), "-jnlp") {
+		javawsArgs = "-jnlp"
 	}
 
 	return javawsArgs
@@ -65,6 +71,7 @@ func main() {
 	var vendor string
 	var username string
 	var password string
+	var javaws string
 	var version int
 
 	pflag.Usage = func() {
@@ -75,15 +82,16 @@ func main() {
 
 	// CLI flags
 	var _host = pflag.StringP("host", "h", "", "The DRAC host (or IP)")
-	var _vendor = pflag.StringP("vendor", "V", "", "The KVM Vendor")
+	var _vendor = pflag.StringP("vendor", "V", "dell", "The KVM Vendor one of (dell/hp/supermicro)")
 
 	var _username = pflag.StringP("username", "u", "", "The KVM username")
 	var _password = pflag.BoolP("password", "p", false, "Prompt for password (optional, will use default vendor if not present)")
-	var _version = pflag.IntP("version", "v", -1, "KVM vendor specific version for idrac: (6, 7 or 8)")
+	var _version = pflag.IntP("version", "v", -1, "KVM vendor specific version for dell: (6, 7 or 8), supermicro: (169 or 170), hp: version autodetected")
 
 	var _delay = pflag.IntP("delay", "d", 10, "Number of seconds to delay for javaws to start up & read jnlp before deleting it")
 	var _javaws = pflag.StringP("javaws", "j", DefaultJavaPath(), "The path to javaws binary")
 	var _wait = pflag.BoolP("wait", "w", false, "Wait for java console process end")
+	var _keep = pflag.BoolP("keep-jnlp", "k", false, "Keep JNLP files and do not clean them after failed start")
 
 	// Parse the CLI flags
 	pflag.Parse()
@@ -94,14 +102,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Check we have access to the javaws binary
-	if _, err := os.Stat(*_javaws); err != nil {
-		log.Fatalf("No javaws binary found at %s", *_javaws)
-	}
-
 	// Search for existing config file
 	usr, _ := user.Current()
 	cfg, _ := goconfig.LoadConfigFile(usr.HomeDir + "/.drackvmrc")
+
+	if value, err := cfg.GetValue("defaults", "javaws_path"); err == nil {
+		javaws = value
+	} else {
+		javaws = *_javaws
+	}
+
+	// Check we have access to the javaws binary
+	if _, err := os.Stat(javaws); err != nil {
+		log.Fatalf("No javaws binary found at %s", javaws)
+	}
 
 	/*
 	 *	Values loaded from config file has lower priority than command line arguments.
@@ -193,13 +207,16 @@ func main() {
 
 	// Launch it!
 	log.Printf("Launching KVM session with %s", filename)
-	cmd := exec.Command(*_javaws, getJavawsArgs(*_wait), filename, "-nosecurity", "-noupdate", "-Xnofork")
+	cmd := exec.Command(javaws, getJavawsArgs(*_wait, javaws), filename, "-nosecurity", "-noupdate", "-Xnofork")
 	if err := cmd.Run(); err != nil {
-		os.Remove(filename)
-		log.Fatalf("Unable to launch DRAC (%s), from file %s", err, filename)
+		if !*_keep {
+			os.Remove(filename)
+		}
+		log.Fatalf("Unable to launch ilo console (%s), from file %s", err, filename)
 	}
 
 	// Give javaws a few seconds to start & read the jnlp
 	time.Sleep(time.Duration(*_delay) * time.Second)
 }
+
 // EOF

--- a/supermicro/ikvm.go
+++ b/supermicro/ikvm.go
@@ -30,6 +30,7 @@ const (
 // the various Supermicro iKVM versions, keyed by version number
 var SupermicroTemplates = map[int]string{
 	169: ikvm169,
+	170: ikvm170,
 }
 
 // Viewer returns a viewer.jnlp template filled out with the

--- a/supermicro/ikvm169.go
+++ b/supermicro/ikvm169.go
@@ -61,4 +61,64 @@ const ikvm169 string = `
 </jnlp>
 `
 
+const ikvm170 string = `
+<jnlp spec="1.0+" codebase="https://{{ .Host }}:443/">
+  <information>
+    <title>ATEN Java iKVM Viewer</title>
+    <vendor>ATEN</vendor>
+    <description>Java Web Start Application</description>
+  </information>
+
+  <security>
+   <all-permissions/>
+  </security>
+
+  <resources>
+    <property name="jnlp.packEnabled" value="true"/>
+    <j2se version="1.6.0+" initial-heap-size="128M" max-heap-size="128M" java-vm-args="-XX:PermSize=32M -XX:MaxPermSize=32M"/>
+    <jar href="iKVM__V1.69.37.0x0.jar" download="eager" main="true"/>
+  </resources>
+
+  <resources os="Windows" arch="x86">
+    <nativelib href="libwin_x86__V1.0.12.jar" download="eager"/>
+  </resources>
+  <resources os="Windows" arch="x86_64">
+    <nativelib href="libwin_x86_64__V1.0.12.jar" download="eager"/>
+  </resources>
+  <resources os="Windows" arch="amd64">
+    <nativelib href="libwin_x86_64__V1.0.12.jar" download="eager"/>
+  </resources>
+
+  <resources os="Linux" arch="i386">
+    <nativelib href="liblinux_x86__V1.0.12.jar" download="eager"/>
+  </resources>
+  <resources os="Linux" arch="x86">
+    <nativelib href="liblinux_x86__V1.0.12.jar" download="eager"/>
+  </resources>
+  <resources os="Linux" arch="x86_64">
+    <nativelib href="liblinux_x86_64__V1.0.12.jar" download="eager"/>
+  </resources>
+  <resources os="Linux" arch="amd64">
+    <nativelib href="liblinux_x86_64__V1.0.12.jar" download="eager"/>
+  </resources>
+
+  <resources os="Mac OS X" arch="x86_64">
+    <nativelib href="libmac_x86_64__V1.0.12.jar" download="eager"/>
+  </resources>
+
+  <application-desc main-class="tw.com.aten.ikvm.KVMMain">
+    <argument>{{ .Host }}</argument>
+    <argument>{{ .Username }}</argument>
+    <argument>{{ .Password }}</argument>
+	  <argument>null</argument>
+    <argument>63630</argument>
+    <argument>623</argument>
+    <argument>0</argument>
+    <argument>0</argument>
+    <argument>1</argument>
+    <argument>5900</argument>
+  </application-desc>
+</jnlp>
+`
+
 // EOF


### PR DESCRIPTION
- Add new version for supermicro provider
- Update dockerfile
- Make sure we can configure javaws_path in config file
- Add proper native jar path for os x for some idrac6 servers
- Fix hp session key name 
- Update Readme with fix for new java releases breaking javaws for old ilo firmwares
- Bump major version

Also should fix #6 